### PR TITLE
This makes uses of a PRNG to create more diverse colors

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const Canvas = require('canvas')
 const axios = require('axios')
 const Stream = require('./stream')
 const randomColor = require('randomcolor')
+const seedrandom = require('seedrandom')
 const imgCache = {}
 const apiCache = {}
 const roomCache = {}
@@ -54,9 +55,11 @@ const readFile = util.promisify(fs.readFile)
 
 function getColor (identifier) {
   if (!colors[identifier]) {
+    Math.seedrandom(identifier);
+    const seed = Math.random().toString();
     colors[identifier] = randomColor({
       luminosity: 'bright',
-      seed: identifier
+      seed
     })
   }
   return colors[identifier]
@@ -79,8 +82,12 @@ async function getMapImage (config, room) {
 module.exports = async (req, res) => {
   if (req.url.match('favico')) return ''
   if (req.url.match('randomColor')) {
-    res.setHeader('content-type', 'application/javascript')
-    return await readFile('./node_modules/randomcolor/randomColor.js', 'utf8')
+      res.setHeader('content-type', 'application/javascript')
+      return await readFile('./node_modules/randomcolor/randomColor.js', 'utf8')
+  }
+  if (req.url.match('seedrandom')) {
+      res.setHeader('content-type', 'application/javascript')
+      return await readFile('./node_modules/seedrandom/seedrandom.js', 'utf8')
   }
   let [, protocol, hostname, port, mode = 'image', roomName] = req.url.split('/')
   if (!protocol || !hostname || !port) {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "micro": "^9.1.0",
     "micro-dev": "^2.2.0",
     "randomcolor": "^0.5.3",
-    "screeps-api": "^1.4.0"
+    "screeps-api": "^1.4.0",
+    "seedrandom": "^2.4.3"
   },
   "scripts": {
     "start": "micro",

--- a/static/viewer.html
+++ b/static/viewer.html
@@ -4,6 +4,7 @@
 		<meta charset="UTF-8">
 		<title>Viewer</title>
 		<script src="/randomColor.js"></script>
+		<script src="/seedrandom.js"></script>
 	</head>
 	<body>
 		<canvas id="canvas"></canvas>
@@ -126,9 +127,11 @@
 
 			function getColor (identifier) {
 			  if (!colors[identifier]) {
+				Math.seedrandom(identifier);
+				const seed = Math.random().toString();
 			    colors[identifier] = randomColor({
 			      luminosity: 'bright',
-			      seed: identifier
+			      seed
 			    })
 			  }
 			  return colors[identifier]

--- a/yarn.lock
+++ b/yarn.lock
@@ -1724,6 +1724,10 @@ screeps-api@^1.4.0:
     utf-8-validate "^3.0.1"
     ws "^3.0.0"
 
+seedrandom@^2.4.3:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/seedrandom/-/seedrandom-2.4.3.tgz#2438504dad33917314bff18ac4d794f16d6aaecc"
+
 "semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"


### PR DESCRIPTION
The previous version had the issue that similar user ids could easily result in similar colors. This approach is now using `seedrandom` with the user id to create more dissimilar color seeds.
It is by no means a perfect solution and similar colors are still absolutely possible, but this heavily reduces them for current test cases.